### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/ini.cpp
+++ b/ini.cpp
@@ -114,12 +114,17 @@ int INIClass::Load(Straw& straw)
 						line[0] = ' ';
 						*strchr(line, ']') = '\0';
 						strtrim(line);
-						INISection* section = new INISection(newstr(line));
-						if (!section)
-						{
-								Clear(0, 0);
-								return false;
+
+						INISection* section;
+
+						try {
+							section = new INISection(newstr(line));
 						}
+						catch (std::bad_alloc& ba) {
+							Clear(0, 0);
+							return false;
+						}
+
 						while (!isLastLine)
 						{
 								int count = Read_Line(cacheStraw, line, 512, isLastLine);
@@ -146,13 +151,17 @@ int INIClass::Load(Straw& straw)
 																		{
 																				continue;
 																		}
-																		INIEntry* entry = new INIEntry(newstr(key), newstr(value));
-																		if (!entry)
-																		{
-																				delete section;
-																				Clear(0, 0);
-																				return false;
+
+																		INIEntry* entry;
+																		try {
+																			entry = new INIEntry(newstr(key), newstr(value));
 																		}
+																		catch (std::bad_alloc& ba) {
+																			delete section;
+																			Clear(0, 0);
+																			return false;
+																		}
+
 																		uint32 crc = CRC_String(entry->Entry, 0);
 																		if (section->EntryIndex.Is_Present(crc))
 																				DuplicateCRCError(__FUNCTION__, section->Section, line);

--- a/vector.h
+++ b/vector.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "CriticalSectionClass.h"
+#include <new>
+
 template <typename T> class NoEqualsClass
 {
 public:
@@ -55,14 +57,15 @@ public:
 			VectorMax = vector.Length();
 			if (VectorMax)
 			{
-				Vector = new T[VectorMax];
-				if (Vector)
-				{
+				try {
+					Vector = new T[VectorMax];
 					IsAllocated = true;
 					for (int index = 0; index < VectorMax; index++)
 					{
 						Vector[index] = vector[index];
 					}
+				}
+				catch (std::bad_alloc& ba) {
 				}
 			}
 			else
@@ -1226,11 +1229,12 @@ public:
 		if (amount >= 0)
 		{
 			int newsize = IndexSize + amount;
-			NodeElement *newindex = new NodeElement[newsize];
-			if (newindex)
-			{
+
+			NodeElement *newindex;
+			try {
+				newindex = new NodeElement[newsize];
 				UL_ASSERT(IndexCount < newsize);
-				for (int i = 0;i < this->IndexCount;i++)
+				for (int i = 0; i < this->IndexCount; i++)
 				{
 					newindex[i].ID = IndexTable[i].ID;
 					newindex[i].Data = IndexTable[i].Data;
@@ -1241,6 +1245,8 @@ public:
 				IndexSize += amount;
 				Invalidate_Archive();
 				return true;
+			}
+			catch (std::bad_alloc& ba) {
 			}
 		}
 		return false;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'Vector' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. vector.h 59
V668 There is no sense in testing the 'newindex' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. vector.h 1230
V668 There is no sense in testing the 'section' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. ini.cpp 118
V668 There is no sense in testing the 'entry' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. ini.cpp 150